### PR TITLE
add support for errorTextAppearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The android and iOS implementations, while very similar in effect, have several 
             errorEnabled="{{ isErrorEnabled }}"
             hintAnimationEnabled="{{ isHintAnimationEnabled }}"
             hintTextAppearance="SpecialTextInputLayout"
+            errorTextAppearance="SpecialErrorTextInputLayout"
             counterEnabled="{{ isCounterEnabled }}">
 
             <!--ONE child element can be added, MUST be either TextField or TextView-->
@@ -49,6 +50,7 @@ error | Text that will display as error message and make the widget look invalid
 errorEnabled | Whether or not an error is enabled for the widget.  If no error, it won't pad the bottom so much.  However, if you set the error attr, it auto-sets this property under the hood to true | Boolean | false
 hintAnimationEnabled | Whether or not the 'float' action of the label should be animated | Boolean | true
 hintTextAppearance | Name of the style definition to apply to the floating label | String | ""
+errorTextAppearance | Name of the style definition to apply to the error message | String | ""
 counterEnabled | Whether or not a char counter should display in bottom-right of widget | Boolean | false
 
 #### Styling
@@ -64,6 +66,10 @@ Simply create a style rule, such as the one below, and set the TextInputLayout's
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="SpecialTextInputLayout" parent="@android:style/TextAppearance">
         <item name="android:textColor">#F9D02A</item>
+        <item name="android:textSize">12dp</item>
+    </style>
+    <style name="SpecialErrorTextInputLayout" parent="@android:style/TextAppearance">
+        <item name="android:textColor">#FF0000</item>
         <item name="android:textSize">12dp</item>
     </style>
 </resources>

--- a/demo/app/App_Resources/Android/values/styles.xml
+++ b/demo/app/App_Resources/Android/values/styles.xml
@@ -4,7 +4,11 @@
         <item name="android:textColor">@color/darkBlue</item>
         <item name="android:textSize">12dp</item>
     </style>
-    
+    <style name="StyledTILError" parent="@android:style/TextAppearance">
+         <item name="android:textStyle">bold|italic</item>
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">12dp</item>
+    </style>
     <!-- theme to use FOR launch screen-->
     <style name="LaunchScreenThemeBase" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="toolbarStyle">@style/NativeScriptToolbarStyle</item>

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -11,6 +11,7 @@
                 android:hintAnimationEnabled="{{ isHintAnimationEnabled }}"
                 android:counterEnabled="{{ isCounterEnabled }}"
                 android:hintTextAppearance="StyledTIL"
+                android:errorTextAppearance="StyledTILError"
                 style="font-family: Arvo-Bold;"
                 >
                 <TextField text="{{ demoText }}" style="font-family: Arvo-Bold;"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-textinputlayout",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A NativeScript plugin to provide an XML widget to implement the Material Design TextInputLayout.",
   "main": "textInputLayout",
   "typings": "textInputLayout.d.ts",

--- a/textInputLayout.android.js
+++ b/textInputLayout.android.js
@@ -19,6 +19,9 @@ exports.hintTextAppearanceProperty = new textInputLayout_common_1.Property({
 exports.counterEnabledProperty = new textInputLayout_common_1.Property({
     name: "counterEnabled", affectsLayout: true, valueConverter: view_1.booleanConverter
 });
+exports.errorTextAppearanceProperty = new textInputLayout_common_1.Property({
+    name: "errorTextAppearance"
+});
 exports.errorEnabledProperty = new textInputLayout_common_1.Property({
     name: "errorEnabled", affectsLayout: true, valueConverter: view_1.booleanConverter
 });
@@ -99,6 +102,12 @@ var TextInputLayout = (function (_super) {
             this.nativeView.setHintTextAppearance(resourceId);
         }
     };
+    TextInputLayout.prototype[exports.errorTextAppearanceProperty.setNative] = function (value) {
+        var resourceId = getStyleResourceId(this._context, value);
+        if (value && resourceId) {
+            this.nativeView.setErrorTextAppearance(resourceId);
+        }
+    };
     TextInputLayout.prototype[exports.errorEnabledProperty.setNative] = function (value) {
         if (!value && (this.error || '').length > 0) {
             this.error = '';
@@ -119,5 +128,6 @@ var TextInputLayout = (function (_super) {
 exports.TextInputLayout = TextInputLayout;
 exports.hintAnimationEnabledProperty.register(TextInputLayout);
 exports.hintTextAppearanceProperty.register(TextInputLayout);
+exports.errorTextAppearanceProperty.register(TextInputLayout);
 exports.counterEnabledProperty.register(TextInputLayout);
 exports.errorEnabledProperty.register(TextInputLayout);

--- a/textInputLayout.android.ts
+++ b/textInputLayout.android.ts
@@ -8,6 +8,7 @@ declare namespace android {
                     setError(error: string): void;
                     setHintAnimationEnabled(value: boolean): void;
                     setHintTextAppearance(resourceId: number): void;
+                    setErrorTextAppearance(resourceId: number): void;
                     setErrorEnabled(enabled: boolean): void;
                     setCounterEnabled(enabled: boolean): void;
                     addView(child, index: number, params): void;
@@ -43,6 +44,10 @@ export const hintTextAppearanceProperty = new Property<TextInputLayout, string>(
 
 export const counterEnabledProperty = new Property<TextInputLayout, boolean>({
     name: "counterEnabled", affectsLayout: true, valueConverter: booleanConverter
+});
+
+export const errorTextAppearanceProperty = new Property<TextInputLayout, string>({
+    name: "errorTextAppearance"
 });
 
 export const errorEnabledProperty = new Property<TextInputLayout, boolean>({
@@ -143,6 +148,13 @@ export class TextInputLayout extends CommonTextInputLayout {
         }
     }
 
+    [errorTextAppearanceProperty.setNative](value: string) {
+        const resourceId = getStyleResourceId(this._context, value);
+        if (value && resourceId) {
+            this.nativeView.setErrorTextAppearance(resourceId);
+        }
+    }
+
     [errorEnabledProperty.setNative](value: boolean) {
         if (!value && (this.error || '').length > 0) {
             this.error = '';
@@ -165,5 +177,6 @@ export class TextInputLayout extends CommonTextInputLayout {
 
 hintAnimationEnabledProperty.register(TextInputLayout);
 hintTextAppearanceProperty.register(TextInputLayout);
+errorTextAppearanceProperty.register(TextInputLayout);
 counterEnabledProperty.register(TextInputLayout);
 errorEnabledProperty.register(TextInputLayout);

--- a/textInputLayout.common.ts
+++ b/textInputLayout.common.ts
@@ -13,6 +13,7 @@ export class TextInputLayout extends View implements TextInputLayoutDefinition {
     //ANDROID ONLY
     public hintAnimationEnabled?: boolean;
     public hintTextAppearance?: string;
+    public errorTextAppearance?: string;
     public counterEnabled?: boolean;
     public errorEnabled?: boolean;
 


### PR DESCRIPTION
I added a new property on the Android side to support errorTextAppearance. This works similar to the hintTextAppearance and allows control over the colors, size, and style of the error message.