### PR TITLE
selectedTitleColor setter fixed and tintColor setter added

### DIFF
--- a/textInputLayout.ios.js
+++ b/textInputLayout.ios.js
@@ -123,8 +123,11 @@ var TextInputLayout = (function (_super) {
     TextInputLayout.prototype[exports.titleFontProperty.setNative] = function (value) {
         this.nativeView.titleFont = value;
     };
-    TextInputLayout.prototype[exports.selectedTitleColorProperty.setNative] = function (value) {
+    TextInputLayout.prototype[exports.tintColorProperty.setNative] = function (value) {
         this.nativeView.tintColor = value instanceof textInputLayout_common_1.Color ? value.ios : value;
+    };
+    TextInputLayout.prototype[exports.selectedTitleColorProperty.setNative] = function (value) {
+        this.nativeView.selectedTitleColor = value instanceof textInputLayout_common_1.Color ? value.ios : value;
     };
     TextInputLayout.prototype[exports.lineColorProperty.setNative] = function (value) {
         this.nativeView.lineColor = value instanceof textInputLayout_common_1.Color ? value.ios : value;

--- a/textInputLayout.ios.ts
+++ b/textInputLayout.ios.ts
@@ -159,8 +159,12 @@ export class TextInputLayout extends TextField implements CommonTextInputLayout 
         this.nativeView.titleFont = value;
     }
 
-    [selectedTitleColorProperty.setNative](value: Color) {
+    [tintColorProperty.setNative](value: Color) {
         this.nativeView.tintColor = value instanceof Color ? value.ios : value;
+    }
+
+    [selectedTitleColorProperty.setNative](value: Color) {
+        this.nativeView.selectedTitleColor = value instanceof Color ? value.ios : value;
     }
 
     [lineColorProperty.setNative](value: Color) {


### PR DESCRIPTION
On iOS, setting the selectedTitleColor property would set the tintColor, and setting the tintColor would be ignored. Updated both instances to set the correct underlying native view property.